### PR TITLE
Expose helper.warnTo

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,8 +6,6 @@ var path = require('path')
 ;
 
 
-module.exports.warnTo = helper.warnTo;
-
 module.exports = function(connInfo, cb) {
     var file = helper.getFileName();
     
@@ -21,3 +19,5 @@ module.exports = function(connInfo, cb) {
         helper.getPassword(connInfo, st, cb);
     });
 };
+
+module.exports.warnTo = helper.warnTo;


### PR DESCRIPTION
`exports` was immediately replaced after exposing warnTo, resulting in warnTo not being exposed.  Re-ordered assignments.