### PR TITLE
Disable warnings when running lsof

### DIFF
--- a/test/#6 too many open files.js
+++ b/test/#6 too many open files.js
@@ -43,7 +43,7 @@ if (lsofBin) {
 		var out = '';
 		var err = '';
 		var lsofArgs = [
-		    '-Fn', '-p', process.pid
+		    '-w', '-Fn', '-p', process.pid
 		];
 		var lsof  = spawn(lsofBin, lsofArgs);
 


### PR DESCRIPTION
Without this system dependent warnings can cause the test to fail, for example because of messages like this:

```
lsof: WARNING: can't stat() fuse.gvfsd-fuse file system /run/user/1001/gvfs
      Output information may be incomplete.
```