### PR TITLE
Fix for when HOME is not defined

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -58,7 +58,7 @@ module.exports.getFileName = function(env){
     var file = env.PGPASSFILE || (
         isWin ?
           path.join( env.APPDATA , 'postgresql', 'pgpass.conf' ) :
-          path.join( env.HOME, '.pgpass' )
+          path.join( env.HOME || '', '.pgpass' )
     );
     return file;
 };


### PR DESCRIPTION
The environment variable `HOME` is not defined for AWS Lambda, so errors like this are encountered when using pg in AWS Lambda:
```
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:28:11)
    at Object.join (path.js:1236:7)
    at Object.module.exports.getFileName (/var/task/node_modules/pgpass/lib/helper.js:61:16)
    at module.exports (/var/task/node_modules/pgpass/lib/index.js:10:23)
    at Connection.<anonymous> (/var/task/node_modules/pg/lib/client.js:137:9)
```

A work-around is to set `HOME` to `/tmp`, as this post suggests:
https://hackernoon.com/writing-a-self-sufficient-aws-lambda-function-da6c0586f48c

See also: https://stackoverflow.com/questions/48653747/how-to-use-node-pg-in-aws-lambda

This took me a while to track down, so hopefully this will help others in the future.