### PR TITLE
Replace split with split2

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -2,7 +2,7 @@
 
 var path = require('path')
   , Stream = require('stream').Stream
-  , Split = require('split')
+  , split = require('split2')
   , util = require('util')
   , defaultPort = 5432
   , isWin = (process.platform === 'win32')
@@ -107,7 +107,7 @@ var matcher = module.exports.match = function(connInfo, entry) {
 
 module.exports.getPassword = function(connInfo, stream, cb) {
     var pass;
-    var lineStream = stream.pipe(new Split());
+    var lineStream = stream.pipe(split());
 
     function onLine(line) {
         var entry = parseLine(line);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Hannes Hörl <hannes.hoerl+pgpass@snowreporter.com>",
   "license": "MIT",
   "dependencies": {
-    "split": "^1.0.1"
+    "split2": "^3.1.1"
   },
   "devDependencies": {
     "jshint": "^2.9.2",


### PR DESCRIPTION
https://github.com/dominictarr/split package is archived and no longer
supported. https://github.com/mcollina/split2 looks like well maintained
fork without very old dependency (through).