### PR TITLE
Upgrade split2@4

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Hannes Hörl <hannes.hoerl+pgpass@snowreporter.com>",
   "license": "MIT",
   "dependencies": {
-    "split2": "^3.1.1"
+    "split2": "^4.1.0"
   },
   "devDependencies": {
     "jshint": "^2.12.0",


### PR DESCRIPTION
`split2@3` depends on `readable-stream`, which is notorious for being [difficult to bundle with rollup due to a circular dependency](https://github.com/nodejs/readable-stream/issues/348). Version `4` does away with this dependency and uses the core node `stream` library instead (and bumps the minimum node version to v12).
I hope this simplifies bundling `node-postgres` with rollup